### PR TITLE
Only use ready workers

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -152,7 +152,9 @@ class WorkerNodes extends EventEmitter {
 
         worker.on('ready', () => {
             this.emitReadyWorkersCount();
-            this.pendingTasksQueue.forEach(() => this.processQueue());
+            if (!this.options.lazyStart) {
+                this.pendingTasksQueue.forEach(() => this.processQueue());
+            }
         });
         worker.on('data', response => this.handleWorkerResponse(worker, response));
         worker.on('exit', exitCode => this.handleWorkerExit(worker));
@@ -246,16 +248,28 @@ class WorkerNodes extends EventEmitter {
      * @returns {Worker}
      */
     pickWorker() {
-        let worker = this.workersQueue.find(worker => worker.canAcceptWork());
+        if (this.options.lazyStart) {
+            let worker = this.workersQueue.find(worker => worker.canAcceptWork());
 
-        if ((!worker || !this.options.lazyStart) && this.canStartWorker()) {
-            worker = this.startWorker();
-        }
+            if (!worker && this.canStartWorker()) {
+                worker = this.startWorker();
+            }
 
-        if (worker) {
-            this.workersQueue.requeue(worker);
-            if (worker.canAcceptWork()) {
+            if (worker) {
+                this.workersQueue.requeue(worker);
                 return worker;
+            }
+        } else {
+            let worker = this.workersQueue.find(worker => worker.canAcceptWork() && worker.isProcessAlive);
+
+            if (worker) {
+                this.workersQueue.requeue(worker);
+                return worker;
+            }
+
+            if (this.canStartWorker()) {
+                this.startWorker();
+                return null;
             }
         }
     }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -150,7 +150,10 @@ class WorkerNodes extends EventEmitter {
     startWorker() {
         const worker = new Worker(this.workerOptions);
 
-        worker.on('ready', () => this.emitReadyWorkersCount());
+        worker.on('ready', () => {
+            this.emitReadyWorkersCount();
+            this.pendingTasksQueue.forEach(() => this.processQueue());
+        });
         worker.on('data', response => this.handleWorkerResponse(worker, response));
         worker.on('exit', exitCode => this.handleWorkerExit(worker));
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -251,7 +251,9 @@ class WorkerNodes extends EventEmitter {
 
         if (worker) {
             this.workersQueue.requeue(worker);
-            return worker;
+            if (worker.canAcceptWork()) {
+                return worker;
+            }
         }
     }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -262,14 +262,13 @@ class WorkerNodes extends EventEmitter {
         } else {
             let worker = this.workersQueue.find(worker => worker.canAcceptWork() && worker.isProcessAlive);
 
+            if (this.canStartWorker()) {
+                this.startWorker();
+            }
+
             if (worker) {
                 this.workersQueue.requeue(worker);
                 return worker;
-            }
-
-            if (this.canStartWorker()) {
-                this.startWorker();
-                return null;
             }
         }
     }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -97,9 +97,16 @@ class Worker extends EventEmitter {
      */
     canAcceptWork() {
         return !this.isTerminating
-            && this.isProcessAlive
             && this.activeCalls < this.maxTasks
             && this.tasksStarted < this.endurance;
+    }
+
+    /**
+     *
+     * @returns {boolean}
+     */
+    isProcessAlive() {
+        return this.isProcessAlive;
     }
 
     /**

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -97,6 +97,7 @@ class Worker extends EventEmitter {
      */
     canAcceptWork() {
         return !this.isTerminating
+            && this.isProcessAlive
             && this.activeCalls < this.maxTasks
             && this.tasksStarted < this.endurance;
     }

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -220,6 +220,37 @@ describe('worker nodes', function () {
             results.forEach(result => result.should.be.at.most(callStartTime));
         });
 
+        it('should only use workers that are fully initialized', function* () {
+            // given
+            workerNodes = new WorkerNodes(fixture('slow-module'), { autoStart: true, minWorkers: 2, maxWorkers: 2 });
+            yield workerNodes.ready();
+
+            // when
+            const firstWorkerPid = yield workerNodes.call.getPid();
+            const secondWorkerPid = yield workerNodes.call.getPid();
+
+            // kill the first worker
+            yield workerNodes.call.exit().catch(error => error);
+
+            // the second worker should receive everything until the new one comes up
+            const pid1 = yield workerNodes.call.getPid();
+            yield workerNodes.call.task100ms();
+            const pid2 = yield workerNodes.call.getPid();
+            yield workerNodes.call.task100ms();
+            const pid3 = yield workerNodes.call.getPid();
+
+            // wait for the slow worker to come up
+            yield workerNodes.call.task200ms();
+            const pid4 = yield workerNodes.call.getPid();
+
+            // then
+            pid1.should.be.eql(secondWorkerPid);
+            pid2.should.be.eql(secondWorkerPid);
+            pid3.should.be.eql(secondWorkerPid);
+
+            pid4.should.not.be.eql(firstWorkerPid);
+            pid4.should.not.be.eql(secondWorkerPid);
+        });
     });
 
     describe('lazy start', function () {

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -169,7 +169,8 @@ describe('worker nodes', function () {
 
     it('should distribute the work evenly among available workers', function* () {
         // given
-        workerNodes = new WorkerNodes(fixture('process-info'), { maxWorkers: 10 });
+        workerNodes = new WorkerNodes(fixture('process-info'), { autoStart: true, maxWorkers: 10, minWorkers: 10 });
+        yield workerNodes.ready();
 
         // when
         const results = yield (10).times.call(workerNodes.call.getPid).and.waitForAllResults();
@@ -260,9 +261,11 @@ describe('worker nodes', function () {
         it('should not affect work assignment to the workers by default', function* () {
             // given
             workerNodes = new WorkerNodes(fixture('process-info'), {
-                minWorkers: 1,
+                autoStart: true,
+                minWorkers: 3,
                 maxWorkers: 3
             });
+            yield workerNodes.ready();
 
             // when
             const results1 = yield workerNodes.call.getPid();
@@ -384,6 +387,8 @@ describe('worker nodes', function () {
         it('should result with rejection of all the calls that the worker was processing at the moment', function* () {
             // given
             workerNodes = yield new WorkerNodes(fixture('async-tasks'), {
+                autoStart: true,
+                minWorkers: 1,
                 maxWorkers: 1,
                 maxTasksPerWorker: 2,
                 taskTimeout: 250,
@@ -495,10 +500,13 @@ describe('worker nodes', function () {
     it('should reject calls that exceeds given limit', function* () {
         // given
         workerNodes = new WorkerNodes(fixture('async-tasks'), {
+            autoStart: true,
+            minWorkers: 2,
             maxWorkers: 2,
             maxTasksPerWorker: 5,
             maxTasks: 5
         });
+        yield workerNodes.ready();
 
         // when
         const results = yield (10).times.call(workerNodes.call.task100ms).and.waitForAllResults();

--- a/tests/fixtures/slow-module.js
+++ b/tests/fixtures/slow-module.js
@@ -1,0 +1,14 @@
+const wait = (delay = 0) => new Promise(resolve => setTimeout(resolve, delay));
+const returnTrue = () => true;
+
+// Simulate slow startup of 0.3 seconds
+const end = process.uptime() + 0.3;
+while (end > process.uptime()) {}
+
+
+module.exports = {
+    getPid: () => process.pid,
+    task100ms: () => wait(100).then(returnTrue),
+    task200ms: () => wait(200).then(returnTrue),
+    exit: () => process.exit(-1)
+};


### PR DESCRIPTION
As we have very time-critical things to do, we don't want workers to accept work when they are in progress of starting up. As they are quite big, they take several seconds.

This PR changes the behaviour so it only uses a worker when its fully ready. If a worker becomes ready it catches up all missed events.

I didn't manage to fix the tests yet (don't merge), but i thought it would be good to let you know what i'm trying to achieve.