### PR TITLE
Prevent workers stopping all at the same time

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,6 +77,7 @@ Describes a WorkerNodes options.
     * [.taskTimeout](#WorkerNodesOptions+taskTimeout) : <code>Number</code>
     * [.taskMaxRetries](#WorkerNodesOptions+taskMaxRetries) : <code>Number</code>
     * [.workerEndurance](#WorkerNodesOptions+workerEndurance) : <code>Number</code>
+    * [.shiftWorkers](#WorkerNodesOptions+shiftWorkers) : <code>Boolean</code>
     * [.workerStopTimeout](#WorkerNodesOptions+workerStopTimeout) : <code>Number</code>
     * [.maxMessageSize](#WorkerNodesOptions+maxMessageSize) : <code>Number</code>
 
@@ -150,6 +151,16 @@ Exceeding this limit causes the termination of the worker.
 
 **Kind**: instance property of <code>[WorkerNodesOptions](#WorkerNodesOptions)</code>  
 **Default**: <code>Infinity</code>  
+<a name="WorkerNodesOptions+shiftWorkers"></a>
+
+### options.shiftWorkers : <code>Boolean</code>
+Whether to shift the stop and start of workers
+
+If shiftWorkers is true, and workerEndurance and autoStart is used, it shifts the stop and start of workers,
+so they don't stop all at the same time.
+
+**Kind**: instance property of <code>[WorkerNodesOptions](#WorkerNodesOptions)</code>  
+**Default**: <code>false</code>  
 <a name="WorkerNodesOptions+workerStopTimeout"></a>
 
 ### options.workerStopTimeout : <code>Number</code>

--- a/lib/options.js
+++ b/lib/options.js
@@ -17,6 +17,7 @@ class WorkerNodesOptions {
         taskMaxRetries = 0,
         workerEndurance = Infinity,
         workerStopTimeout = 100,
+        shiftWorkers = false,
         maxMessageSize = 8 * 1024 * 1024
     } = {}) {
         /**
@@ -97,6 +98,17 @@ class WorkerNodesOptions {
          * @default Infinity
          */
         this.workerEndurance = Number(workerEndurance);
+
+        /**
+         * Whether to shift the stop and start of workers
+         *
+         * If shiftWorkers is true, and workerEndurance and autoStart is used, it shifts the stop and start of workers,
+         * so they don't stop all at the same time.
+         *
+         * @type {Boolean}
+         * @default false
+         */
+        this.shiftWorkers = Boolean(shiftWorkers);
 
         /**
          * The timeout value (in milliseconds) for the worker to stop before sending SIGKILL.

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -34,6 +34,11 @@ class WorkerNodes extends EventEmitter {
 
         this.callHandlers = {};
 
+        // Calculate the amount of shift for workers
+        this.shiftAmount = 0;
+        if (this.options.shiftWorkers && Number.isFinite(this.options.workerEndurance))
+            this.shiftAmount = Math.floor(this.options.workerEndurance / this.options.maxWorkers);
+
         /**
          * This exposes the api of a module that the worker nodes are working on. If the module is a function, you
          * can call this directly. If the module exports multiple functions, you can call them as they were properties
@@ -69,9 +74,13 @@ class WorkerNodes extends EventEmitter {
 
             if (this.options.autoStart) {
                 if (this.options.lazyStart) {
-                    for (let i = 0; i < this.options.minWorkers; i++) this.startWorker();
+                    for (let i = 0; i < this.options.minWorkers; i++) this.startWorker(i * this.shiftAmount);
                 } else {
-                    while (this.canStartWorker()) this.startWorker();
+                    let offset = 0;
+                    while (this.canStartWorker()) {
+                        this.startWorker(offset);
+                        offset = offset + this.shiftAmount
+                    }
                 }
             }
 
@@ -145,10 +154,12 @@ class WorkerNodes extends EventEmitter {
     /**
      * Spawns and setups a new worker.
      *
+     * @param {Number} offset
      * @private
      */
-    startWorker() {
-        const worker = new Worker(this.workerOptions);
+    startWorker(offset = 0) {
+        let workerOptions = Object.assign({offset}, this.workerOptions);
+        const worker = new Worker(workerOptions);
 
         worker.on('ready', () => {
             this.emitReadyWorkersCount();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -10,12 +10,12 @@ const ProcessResponse = messages.Response;
 const workerSerial = new Sequence(1);
 
 class Worker extends EventEmitter {
-    constructor({ srcFilePath, maxTasks, maxMessageSize, endurance, stopTimeout }) {
+    constructor({ srcFilePath, maxTasks, maxMessageSize, endurance, stopTimeout, offset }) {
         super();
 
         this.id = workerSerial.nextValue();
         this.calls = new Map();
-        this.tasksStarted = 0;
+        this.tasksStarted = offset || 0;
         this.maxTasks = maxTasks;
         this.endurance = endurance;
         this.isTerminating = false;

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -179,6 +179,25 @@ describe('worker nodes', function () {
         unique(results).should.have.lengthOf(10);
     });
 
+    it('should start workers with an offset', function* () {
+        // given
+        workerNodes = new WorkerNodes(fixture('async-tasks'), {
+            autoStart: true,
+            maxWorkers: 4,
+            minWorkers: 4,
+            workerEndurance: 40,
+            shiftWorkers: true
+        });
+        yield workerNodes.ready();
+
+        // when
+        const offsets = workerNodes.workersQueue.storage.map(storage => storage.tasksStarted);
+
+        // then
+        unique(offsets).should.have.lengthOf(4);
+        offsets.should.deep.equal([ 0, 10, 20, 30 ]);
+    });
+
     describe('auto-start', function () {
 
         it('should be disabled by default', function* () {


### PR DESCRIPTION
Here is another improvement for time critical use of the workers:
When they have a limited lifetime, set with `workerEndurance` they all end at the same time.
Then no worker is left to process any request until the first worker is up again.

With this PR it shifts workers by adding an `offset` to their `tasksStarted` variable on the first start of the Workers, so they end earlier in the first iteration.

After that iteration they will just continue to run normally, but with a smaller chance that two of them end at the same time because they are shifted to each other.

What do you think of this approach?