### PR TITLE
improve slow-worker test

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "jsdoc-to-markdown": "^2.0.1",
     "lodash.uniq": "^4.5.0",
     "mocha": "^3.1.2",
-    "sinon": "^1.17.6"
+    "sinon": "^1.17.6",
+    "test-until": "^1.0.2"
   },
   "dependencies": {
     "bson": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "jsdoc-to-markdown": "^2.0.1",
     "lodash.uniq": "^4.5.0",
     "mocha": "^3.1.2",
-    "sinon": "^1.17.6",
-    "test-until": "^1.0.2"
+    "sinon": "^1.17.6"
   },
   "dependencies": {
     "bson": "^1.0.1"

--- a/tests/fixtures/slow-module.js
+++ b/tests/fixtures/slow-module.js
@@ -9,6 +9,5 @@ while (end > process.uptime()) {}
 module.exports = {
     getPid: () => process.pid,
     task100ms: () => wait(100).then(returnTrue),
-    task200ms: () => wait(200).then(returnTrue),
     exit: () => process.exit(-1)
 };

--- a/tests/fixtures/slow-module.js
+++ b/tests/fixtures/slow-module.js
@@ -1,13 +1,8 @@
-const wait = (delay = 0) => new Promise(resolve => setTimeout(resolve, delay));
-const returnTrue = () => true;
-
 // Simulate slow startup of 0.3 seconds
 const end = process.uptime() + 0.3;
 while (end > process.uptime()) {}
 
 
 module.exports = {
-    getPid: () => process.pid,
-    task100ms: () => wait(100).then(returnTrue),
-    exit: () => process.exit(-1)
+    getPid: () => process.pid
 };


### PR DESCRIPTION
Looks like my test does not work well on Travis-CI (or maybe other slow environments).
This test really "waits" until the workers are alive, instead of just hoping that they are started after ~400ms .