### PR TITLE
remove array destructuring statements

### DIFF
--- a/lib/worker/transport.js
+++ b/lib/worker/transport.js
@@ -19,7 +19,7 @@ class Transport extends EventEmitter {
 
         const checkBuffer = () => {
             const headerLength = Uint32Array.BYTES_PER_ELEMENT;
-            const [ bodyLength ] = new Uint32Array(buffer.buffer, 0, 1);
+            const bodyLength = new Uint32Array(buffer.buffer, 0, 1)[0];
             const totalMsgLength = headerLength + bodyLength;
 
             if (bufferPointer > headerLength && bufferPointer >= totalMsgLength) {


### PR DESCRIPTION
* v8 marks functions that uses array destructuring as 'not optimized: TryCatchStatement'