### PR TITLE
msgpack streaming seems to be slow; use expanding buffer instead (#18)

### DIFF
--- a/lib/worker/transport.js
+++ b/lib/worker/transport.js
@@ -1,30 +1,62 @@
 const EventEmitter = require('events');
 const msgpack = require("msgpack-lite");
 
+const BUFFER_INITIAL_SIZE = 1024 * 1024; // 1MB
+const BUFFER_GROW_RATIO = 1.5;
+
 class Transport extends EventEmitter {
-  constructor(socket) {
-    super();
-    this.socket = socket;
-    this.socket.on('error', Transport._ignorePipeErrors);
+    constructor(pipe) {
+        super();
 
-    this.decodeStream = msgpack.createDecodeStream();
-    this.socket.pipe(this.decodeStream)
-               .on('data', message => this.emit('message', message));
-  }
+        let buffer = Buffer.alloc(BUFFER_INITIAL_SIZE);
+        let bufferPointer = 0;
 
+        this.pipe = pipe;
 
-  send(message) {
-    const encodeStream = msgpack.createEncodeStream()
-                                .on('data', data => this.socket.write(data));
-    encodeStream.write(message);
-    encodeStream.end();
-  }
+        const processChunk = dataChunk => {
+            // extend the buffer to ensure that it is
+            // large enough to store the incoming chunk
+            while (bufferPointer + dataChunk.byteLength > buffer.byteLength) {
+                const newBuffer = Buffer.alloc(buffer.byteLength * BUFFER_GROW_RATIO);
+                buffer.copy(newBuffer);
+                buffer = newBuffer;
+            }
 
-  static _ignorePipeErrors(err) {
-    if (!['EPIPE', 'ECONNRESET'].includes(err.code)) {
-      throw err;
+            bufferPointer += dataChunk.copy(buffer, bufferPointer);
+            checkBuffer();
+        };
+
+        const checkBuffer = () => {
+            const headerLength = Uint32Array.BYTES_PER_ELEMENT;
+            const bodyLength = new Uint32Array(buffer.buffer, 0, 1)[0];
+            const totalMsgLength = headerLength + bodyLength;
+
+            if (bufferPointer > headerLength && bufferPointer >= totalMsgLength) {
+                const message = msgpack.decode(buffer.slice(headerLength, headerLength + bodyLength));
+
+                this.emit('message', message);
+
+                // copy remaining chunk to the start of the buffer and reset pointers
+                buffer.copy(buffer, 0, totalMsgLength, bufferPointer);
+                bufferPointer = bufferPointer - totalMsgLength;
+
+                if (bufferPointer >= headerLength) {
+                    checkBuffer();
+                }
+            }
+        };
+
+        pipe.on('error', console.error);
+        pipe.on('data', processChunk);
     }
-  }
+
+    send(message) {
+        const serializedMessage = msgpack.encode(message);
+        const header = new Uint32Array([ serializedMessage.byteLength ]);
+
+        this.pipe.write(Buffer.from(header.buffer));
+        this.pipe.write(serializedMessage);
+    }
 }
 
 module.exports = Transport;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker-nodes",
-  "version": "1.5.0",
+  "version": "1.6.0-bata.1",
   "description": "A library to run cpu-intensive tasks without blocking the event loop.",
   "keywords": [
     "workers",


### PR DESCRIPTION
Hey @noam-almog, as you said in https://github.com/allegro/node-worker-nodes/issues/18#issuecomment-327177953 enabling streaming was a way to fix issue with buffer overflow.

This change will also cover this, but without relaying on message-pack's implementation of streaming which seems to not work performant in our setup. The code simply makes the message buffer to accommodate to the received object.

And as we use message-pack instead of BSON (thanks to you! :)), there are no problems with encoding/sending large objects, so that part is not touched.

Quick tests showed that it works. What do you think about this? Am I missing something? :)