### PR TITLE
Add test case for rejected promise

### DIFF
--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -558,6 +558,32 @@ describe('worker nodes', function () {
                 .that.has.property('message', 'cancel after 3 retries!');
         });
 
+        it('should catch thrown exceptions', function* () {
+            // given
+            const workerNodes = givenWorkerPoolWith('harmful-module', { maxWorkers: 1, taskMaxRetries: 0 });
+
+            // when
+            const result = yield workerNodes.call.throwsAlways().catch(error => error);
+
+            // then
+            result.should.be
+                .an.instanceOf(Error)
+                .that.has.property('message', 'thrown');
+        });
+
+        it('should catch rejected promises', function* () {
+            // given
+            const workerNodes = givenWorkerPoolWith('harmful-module', { maxWorkers: 1, taskMaxRetries: 0 });
+
+            // when
+            const result = yield workerNodes.call.rejectAlways().catch(error => error);
+
+            // then
+            result.should.be
+                .an.instanceOf(Error)
+                .that.has.property('message', 'rejected');
+        });
+
         it('should be successful if previously failing task would reconsider its behaviour', function* () {
             // given
             const workerNodes = givenWorkerPoolWith('harmful-module', { maxWorkers: 1, taskMaxRetries: 3 });

--- a/tests/fixtures/harmful-module.js
+++ b/tests/fixtures/harmful-module.js
@@ -9,6 +9,14 @@ module.exports = {
 
     infiniteLoop: () => { while (true); },
 
+    throwsAlways: () => { throw new Error('thrown'); },
+
+    rejectAlways: () => {
+        return new Promise(function(resolve, reject) {
+            reject(new Error('rejected'));
+        });
+    },
+
     setSomeJobFailsNumber: number => fs.writeFileSync(tmpFile, String(number)),
     someJob() {
         let failsLeft = fs.existsSync(tmpFile) ? parseInt(fs.readFileSync(tmpFile, 'utf8')) : 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,11 +195,11 @@ core-js@^2.4.0, core-js@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-debug@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+debug@2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
-    ms "0.7.1"
+    ms "2.0.0"
 
 deep-eql@^0.1.3:
   version "0.1.3"
@@ -215,9 +215,9 @@ defer-promise@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defer-promise/-/defer-promise-1.0.0.tgz#43c94a8a3e1e2699a114ea86a18fa9d5f83bca85"
 
-diff@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+diff@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 dmd@^2.1.2:
   version "2.1.2"
@@ -288,18 +288,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-glob@7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.0:
+glob@7.1.1, glob@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -334,6 +323,10 @@ handlebars@3.0.3:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 home-path@^1.0.3:
   version "1.0.3"
@@ -539,25 +532,26 @@ mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.1.2.tgz#51f93b432bf7e1b175ffc22883ccd0be32dba6b5"
+mocha@^3.4.2:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"
-    debug "2.2.0"
-    diff "1.4.0"
+    debug "2.6.8"
+    diff "3.2.0"
     escape-string-regexp "1.0.5"
-    glob "7.0.5"
+    glob "7.1.1"
     growl "1.9.2"
+    he "1.1.1"
     json3 "3.3.2"
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 msgpack-lite@^0.1.26:
   version "0.1.26"


### PR DESCRIPTION
This solves #26 showing that we catch rejected promises, but they have to throw an error (have an argument). I do not know if this intended behaviour: @kwiatkk1 

The failing test case is shown here: https://github.com/allegro/node-worker-nodes/tree/check-catching-errors-failing-testcasase

A small example is shown here @wuchuguang -> https://github.com/slonka/node-worker-nodes-promise-reject