### PR TITLE
#32 fix --inspector ip address debug port error

### DIFF
--- a/lib/worker/process.js
+++ b/lib/worker/process.js
@@ -4,7 +4,7 @@ const EventEmitter = require('events');
 const Transport = require('./transport');
 
 const execArgsProcessor = {
-    debugOptionPattern: /^(--inspect(?:-brk)?|--debug|--debug-(brk|port))(=\d+)?$/,
+    debugOptionPattern:  /^(--inspect(?:-brk)?|--debug|--debug-(brk|port))(=(\d+\.){3}\d+(\:\d+)?)?$/,
     offset: 1,
 
     map(execArgv) {


### PR DESCRIPTION
Fixes https://github.com/allegro/node-worker-nodes/issues/32 

fix for 'unable to open devtools socket' error when passing an ip address to --inspect