### PR TITLE
Spawn a new worker when an old one is stopped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [12.x, 16.x, 18.x, 20.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     
     runs-on: ${{ matrix.platform }}

--- a/e2e/spawn-new-workers-on-stop.spec.js
+++ b/e2e/spawn-new-workers-on-stop.spec.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 
 const WorkerNodes = require('..');
-const { fixture, repeatCall, wait, eventually } = require('./utils');
+const { fixture, repeatCall, eventually } = require('./utils');
 
 
 test('should spawn new workers when old workers exit even if no items in the queue', async (t) => {
@@ -37,6 +37,9 @@ test('should shutdown fine', async (t) => {
 
     await workerNodes.ready();
     await t.notThrowsAsync(() => workerNodes.terminate());
-    await wait(200);
-    t.is(workerNodes.workersQueue.filter((worker) => worker.isProcessAlive).length, 0);
+    
+    const getAliveWorkersCount = () => workerNodes.workersQueue.filter((worker) => worker.isProcessAlive).length;
+
+    await eventually(() => getAliveWorkersCount() === 0);
+    t.is(getAliveWorkersCount(), 0);
 });

--- a/e2e/spawn-new-workers-on-stop.spec.js
+++ b/e2e/spawn-new-workers-on-stop.spec.js
@@ -25,3 +25,16 @@ test('should spawn new workers when old workers exit even if no items in the que
     const operationWorkersCountAfter = workerNodes.workersQueue.filter((worker) => worker.isOperational()).length;
     t.is(operationWorkersCountAfter, maxWorkers);
 });
+
+
+test('should shutdown fine', async (t) => {
+    // given
+    const maxWorkers = 4;
+    const minWorkers = 2;
+    const workerNodes = new WorkerNodes(fixture('process-info'), { maxWorkers, minWorkers, workerEndurance: 1, autoStart: true });
+
+    await workerNodes.ready();
+    await t.notThrowsAsync(() => workerNodes.terminate());
+    await wait(200);
+    t.is(workerNodes.workersQueue.filter((worker) => worker.isProcessAlive).length, 0);
+});

--- a/e2e/spawn-new-workers-on-stop.spec.js
+++ b/e2e/spawn-new-workers-on-stop.spec.js
@@ -1,0 +1,27 @@
+const test = require('ava');
+
+const WorkerNodes = require('..');
+const { fixture, repeatCall, wait } = require('./utils');
+
+
+test('should spawn new workers when old workers exit even if no items in the queue', async (t) => {
+    // given
+    const maxWorkers = 4;
+    const minWorkers = 2;
+    const workerNodes = new WorkerNodes(fixture('process-info'), { maxWorkers, minWorkers, workerEndurance: 1, autoStart: true });
+
+    await workerNodes.ready();
+
+    const operationWorkersCountBefore = workerNodes.workersQueue.filter((worker) => worker.isOperational()).length;
+    t.is(operationWorkersCountBefore, minWorkers);
+
+    // when
+    await repeatCall(workerNodes.call.noop, maxWorkers);
+    t.is(workerNodes.workersQueue.filter((worker) => worker.isOperational()).length, 0);
+
+    await wait(200);
+
+    // then
+    const operationWorkersCountAfter = workerNodes.workersQueue.filter((worker) => worker.isOperational()).length;
+    t.is(operationWorkersCountAfter, maxWorkers);
+});

--- a/e2e/spawn-new-workers-on-stop.spec.js
+++ b/e2e/spawn-new-workers-on-stop.spec.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 
 const WorkerNodes = require('..');
-const { fixture, repeatCall, wait } = require('./utils');
+const { fixture, repeatCall, wait, eventually } = require('./utils');
 
 
 test('should spawn new workers when old workers exit even if no items in the queue', async (t) => {
@@ -19,11 +19,13 @@ test('should spawn new workers when old workers exit even if no items in the que
     await repeatCall(workerNodes.call.noop, maxWorkers);
     t.is(workerNodes.workersQueue.filter((worker) => worker.isOperational()).length, 0);
 
-    await wait(200);
+
+    const getOperationalWorkersCount = () => workerNodes.workersQueue.filter((worker) => worker.isOperational()).length;
 
     // then
-    const operationWorkersCountAfter = workerNodes.workersQueue.filter((worker) => worker.isOperational()).length;
-    t.is(operationWorkersCountAfter, maxWorkers);
+    // we're waiting to all workers to be operational, the time for that might variate greatly between machines (Developer machine vs CI machine)
+    await eventually(() => getOperationalWorkersCount() === maxWorkers);
+    t.is(getOperationalWorkersCount(), maxWorkers);
 });
 
 

--- a/e2e/utils/index.js
+++ b/e2e/utils/index.js
@@ -5,3 +5,38 @@ module.exports.unique = elements => [...new Set(elements)];
 module.exports.repeatCall = (call, count) => Promise.all(new Array(count).fill().map(async () => await call()));
 
 module.exports.wait = delay => new Promise(resolve => setTimeout(resolve, delay));
+
+function getPromiseDescriptor() {
+    let promiseResolve, promiseReject 
+    const promise = new Promise((resolve, reject) => {
+        promiseResolve = resolve;
+        promiseReject = reject
+    });
+
+    return {
+        promise,
+        resolve: promiseResolve,
+        reject: promiseReject,
+    };
+}
+
+module.exports.eventually = async (predicate, timeout = 5000) => {
+    const promiseDescriptor = getPromiseDescriptor();
+    const startTime = Date.now();
+    
+    do {
+        try {
+            const result = await predicate();
+            if (result) {
+                promiseDescriptor.resolve(result);
+            }
+        } catch (ex) {
+            console.warn(`eventually(): provided predicate throwed: ${ex.message}`);
+        }
+        await this.wait(100);
+    } while (Date.now() < startTime + timeout);
+
+    promiseDescriptor.reject(new Error(`Timed out waiting ${timeout}ms for predicate`));
+
+    return promiseDescriptor.promise;
+}

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -141,7 +141,7 @@ class WorkerNodes extends EventEmitter {
      * @returns {boolean} true if it's possible to spawn a new worker
      */
     canStartWorker() {
-        return !this.workersQueue.isFull();
+        return !this.isTerminationStarted && !this.workersQueue.isFull();
     }
 
     /**

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -120,6 +120,8 @@ class WorkerNodes extends EventEmitter {
 
         this.workersQueue.remove(worker);
 
+        if (this.canStartWorker()) this.startWorker();
+
         this.processQueue();
     }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -120,7 +120,9 @@ class WorkerNodes extends EventEmitter {
 
         this.workersQueue.remove(worker);
 
-        if (this.canStartWorker()) this.startWorker();
+        setImmediate(() => {
+            if (this.canStartWorker()) this.startWorker();
+        });
 
         this.processQueue();
     }


### PR DESCRIPTION
Hi 👋 
Thank you for your work in this great library 🙏 

In my scenario, I run a task in a process that contaminates global process space, I would like each task to have a separate process (`workerEndurance = 1`).

When worker is exhausted at the moment, no other worker replaces it if the queue is empty, that makes the worker pool to go to zero and then start spawning workers only when new tasks arrive, that's not so ideal IMO.

This PR changes the behavior in such a way that for each exited worker, if we can accommodate it, we spawn a new one immediately.

Have a great day!